### PR TITLE
Replace Ingress controller with Gateway API in EKS guide

### DIFF
--- a/docs/5-cloud-computing/5.2.7-eks.md
+++ b/docs/5-cloud-computing/5.2.7-eks.md
@@ -44,8 +44,8 @@ docs/5-cloud-computing/5.2.6-ecs.md:
       - AWS EKS
       - Kubernetes
     -
-      name: Add an Ingress controller and your cluster
-      description: Add an Ingress controller and your cluster
+      name: Configure the Gateway API for your cluster
+      description: Configure the Gateway API for your cluster
       estMinutes: 60
       technologies:
       - AWS
@@ -224,27 +224,29 @@ Now you will add an autoscaler to your cluster that will automatically scale you
 
 5. Delete your `NAME-bc-svc` namespace when finished.
 
-## Ingresses
+## Gateway API
 
 Ingresses are a Kubernetes resource that create an entry point for network traffic to be routed from outside our cluster to pods running in the cluster, similar to a Service of type LoadBalancer but more configurable. The specifics of how traffic is routed into the cluster depend on the network the cluster is running in and is therefore heavily dependent on the platform. For our EKS cluster, AWS uses Application or Network Load Balancers. The Load Balancers are created and configured automatically for us by the AWS Load Balancer Controller when we create an Ingress resource. Read more about [Application load balancing on Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html) and the [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/).
 
-?> The AWS Load Balancer Controller is automatically provisioned when we create an EKS cluster so we don't need to install it.
+—
 
-In order for an Ingress to route traffic from our network load balancer to our pods, we also need an Ingress Controller. Read more about [Ingresses](https://kubernetes.io/docs/concepts/services-networking/ingress/) and [Ingress Controllers](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/)
+The Gateway API is the newer, more expressive successor to Ingress for routing network traffic into a Kubernetes cluster. It splits responsibilities across a few resources: a GatewayClass (defines which controller handles the traffic and what infrastructure it provisions), a Gateway (the actual listener/load balancer instance, including things like ports and TLS), and a route resource (HTTPRoute for this exercise) that define how traffic is matched and forwarded to backend Services. [More information on Gateway API.](https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/)
 
-## Exercise - Adding an Ingress and Ingress Controller to your cluster
+In order for Gateway API to route traffic from our network load balancer to our pods, we also need a Gateway Controller. Read more about the [Gateway API](https://kubernetes.io/docs/concepts/services-networking/gateway/) and [Gateway Controllers](https://gateway-api.sigs.k8s.io/docs/implementations/list/).
 
-We will add an Ingress controller so that you can access this cluster without having to use port-forwarding.
+## Exercise - Adding a Gateway and Gateway Controller to your cluster
 
-1. Install the NGINX Ingress controller. There are different controllers to choose from, but the NGINX Ingress controller works with AWS. [You can learn more here](https://kubernetes.github.io/ingress-nginx/).
+So far we've exposed traffic using Service types (ClusterIP with port-forwarding, NodePort, and LoadBalancer). Now we'll configure the Gateway API, which gives us more configurable routing than a Service alone provides.
 
-2. Create an Ingress resource to talk to the NGINX Ingress controller with the name `sock-shop-ingress` inside the sock-shop namespace.
+?> Do not use helm or eksctl. Using `aws` and `kubectl` directly requires more manual setup, allowing for a deeper understanding.
 
-?> Make sure to include the `ingressClassName` if you're using a K8s version ≥ 1.19.
+1. Install the Gateway controller. There are different controllers to choose from, but the Envoy controller is recommended. More information about other controllers can be found [here](https://gateway-api.sigs.k8s.io/docs/implementations/list/).
 
-3. Run `kubectl get Ingress -n sock-shop` in order to get the address of your Ingress.
+2. Create and apply a GatewayClass, Gateway, and an HTTPRoute configuration to the sock-shop namespace.
 
-5. Make sure that your cluster works the same way that it would when you were port-forwarding it.
+3. Run `kubectl describe gateway <gateway-name> -n sock-shop` in order to get the address of your application.
+
+4. Make sure that your cluster works the same way that it would when you were port-forwarding it.
 
 ## Deliverables
 
@@ -252,4 +254,4 @@ We will add an Ingress controller so that you can access this cluster without ha
 - Explain how services remedy the difficulties of ephemeral pods
 - Describe the benefits/drawbacks of using EKS in enterprise
 - Discuss why adding an IAM role policy in the autoscaler exercise might be a bad idea, and why [fine-grained IAM roles](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) are better.
-- Discuss how Ingresses are different from Services
+- Discuss how the Gateway API is different from Services

--- a/docs/5-cloud-computing/5.2.7-eks.md
+++ b/docs/5-cloud-computing/5.2.7-eks.md
@@ -240,7 +240,7 @@ So far we've exposed traffic using Service types (ClusterIP with port-forwarding
 
 ?> Do not use helm or eksctl. Using `aws` and `kubectl` directly requires more manual setup, allowing for a deeper understanding.
 
-1. Install the Gateway controller. There are different controllers to choose from, but the Envoy controller is recommended. More information about other controllers can be found [here](https://gateway-api.sigs.k8s.io/docs/implementations/list/).
+1. Install the Gateway controller. There are different controllers to choose from, but the Envoy controller is recommended. More information about other controllers can be found [Gateway API controller implementations](https://gateway-api.sigs.k8s.io/docs/implementations/list/).
 
 2. Create and apply a GatewayClass, Gateway, and an HTTPRoute configuration to the sock-shop namespace.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -742,8 +742,8 @@ docs/5-cloud-computing/5.2.6-ecs.md:
         - AWS
         - AWS EKS
         - Kubernetes
-    - name: Add an Ingress controller and your cluster
-      description: Add an Ingress controller and your cluster
+    - name: Configure the Gateway API for your cluster
+      description: Configure the Gateway API for your cluster
       estMinutes: 60
       technologies:
         - AWS


### PR DESCRIPTION
Updated the document to replace Ingress controller references with Gateway API and adjusted related sections accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the EKS exercise to use the Gateway API instead of an Ingress controller.
  * Added guidance for configuring Gateway API controllers, Gateway resources, and HTTPRoutes.
  * Updated validation steps and deliverables to include comparing the Gateway API with Services.
  * Renamed the exercise in the documentation index and updated its description.
  * Improved controller installation instructions with descriptive links identifying available implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->