### PR TITLE
Update 6.3.1-branching-merging.md

### DIFF
--- a/docs/6-software-development-practices/6.3.1-branching-merging.md
+++ b/docs/6-software-development-practices/6.3.1-branching-merging.md
@@ -19,13 +19,9 @@ Before we get into the specifics of how version control works let's examine two 
 >
 > _- Kent Beck, from [Martin Fowler's Patterns for Managing Source Code Branches](https://martinfowler.com/articles/branching-patterns.html)_
 
-## Branching Strategies
+## Branching Best Practices
 
-As software development practices have evolved over time so have opinions about branching strategies. Sometimes these opinions can be a contentious issue. Read [GitFlow considered harmful](http://endoflineblog.com/gitflow-considered-harmful) and [the follow up](http://endoflineblog.com/follow-up-to-gitflow-considered-harmful) for some background on opinions of different strategies.
-
-### Branching Best Practices
-
-Now let's take a look at Liatrio's point of view on branching.
+As software development practices have evolved, so have opinions on branching strategies. Sometimes those opinions clash--see [GitFlow considered harmful](http://endoflineblog.com/gitflow-considered-harmful) and [the follow up](http://endoflineblog.com/follow-up-to-gitflow-considered-harmful) for some background. Liatrio's stance is as follows:
 
 **Guidelines for a good branching strategy**
 


### PR DESCRIPTION
Merge Branching Strategies and Best Practices headers into one

- Merge "Branching Strategies" into "Branching Best Practices" header; the intro section was too thin to stand on its own
- Rework intro paragraph: trim redundant wording, fix "these opinions can be a contentious issue" (opinions aren't an issue, the topic is), and replace the "point of view" transition with a direct lead-in to Liatrio's recommendations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed the section to “Branching Best Practices.”
  * Replaced the introductory discussion with a concise overview of the recommended branching approach.
  * Updated wording and reference links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->