### PR TITLE
Fix typo in 6.3.2-git.md

### DIFF
--- a/docs/6-software-development-practices/6.3.2-git.md
+++ b/docs/6-software-development-practices/6.3.2-git.md
@@ -107,7 +107,7 @@ The staging area is a temporary location in Git that allows you to continue maki
 
 ![Git Staging](../../img/git-staging.webp ':class=img-shadow')
 
-?> When adding files to staging you can specify a directory to add all new or changes files in that directory. Always use `git status` after adding a folder to avoid accidentally adding hidden or unwanted files.
+?> When adding files to staging you can specify a directory to add all new or changed files in that directory. Always use `git status` after adding a folder to avoid accidentally adding hidden or unwanted files.
 
 ?> Each commit requires a message which should concisely describe what is being changed. To avoid Git opening a text editor to add a message to the commit use the message argument in the command `git commit -m "COMMIT MESSAGE"`.
 


### PR DESCRIPTION
Fix typo from
"... all new or changes files ..." to
"... all new or changed files ..."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the Git guide describing how to stage new or changed files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->