### PR TITLE
Update 6.3.2-git.md

### DIFF
--- a/docs/6-software-development-practices/6.3.2-git.md
+++ b/docs/6-software-development-practices/6.3.2-git.md
@@ -145,7 +145,7 @@ Branching allows you to diverge from the main line of development and continue t
 
 ### Developer Workflow & Git Lifecycle
 
-A typical developer workflow is centered around using Git. Using TBE principles, engineers create a branch tied to the work item, commit changes locally, and submit a pull request on the remote Git server.
+A typical developer workflow is centered around using Git. Using <span title="trunk-based development">TBD</span> principles, engineers create a branch tied to the work item, commit changes locally, and submit a pull request on the remote Git server.
 
 ![The cycle of pulling, changing, committing, and pushing that is used with Git](img6/git-lifecycle.svg ':size=600px :class=img-center')
 


### PR DESCRIPTION
Changes "TBE principles" to "TBD principles"
to stay consistent with term usage in prior section (6.3.1) where "truck-based development" is used.

Also wraps in `<span title="trunk-based development">` so that hovering over "TBD" shows the meaning.

The choice of "development" here is also more appropriate, as this has everything to do with *development* practices and touches *engineering* only insofar as development overlaps with engineering.

Being able to get a dotted underline that `<abbr>` normally provides would be nice, but the rendered preview of the markdown+html doesn't appear to support that usage--no underline appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the Git workflow acronym from “TBE” to “TBD.”
  - Added a tooltip clarifying that “TBD” means “trunk-based development.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->