### PR TITLE
resolve: dependabot alert #148 (quadratic CPU consumption/DoS vuln)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5189,9 +5189,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
This is due to the package-lock.json file in the repo root specifying 2 things:

### 1. The dependency version range (lines 5168 - 5181)
```json

    "node_modules/gray-matter": {
      "version": "4.0.3",
      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
      "dependencies": {
------> "js-yaml": "^3.13.1",
        "kind-of": "^6.0.2",
        "section-matter": "^1.0.0",
        "strip-bom-string": "^1.0.0"
      },
      "engines": {
        "node": ">=6.0"
      }
    },
```
`"js-yaml": "^3.13.1",` says `js-yaml` must be:
at or above `3.13.1` and below `4.0.0`,
i.e.`3.13.1` <= `js-yaml` < `4.0.0`

### 2. The locked version in package-lock.json (lines 5191 - 5203)
```json
    "node_modules/gray-matter/node_modules/js-yaml": {
----> "version": "3.15.0",
      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
----> "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
      "license": "MIT",
      "dependencies": {
        "argparse": "^1.0.7",
        "esprima": "^4.0.0"
      },
      "bin": {
        "js-yaml": "bin/js-yaml.js"
      }
    },
```
The `"version": "3.15.0",` and `"integrity": "sha512-ttBQIIQPDeL..."` prevent updating, telling the system to prefer the old version, even though the new version satisfies the dependency requirement.

### The fix
Simply run `npm update js-yaml` on a local clone of the repo to update the relevant package-lock.json entry, then `git push`.