### PR TITLE
Change wording in 6.5.4-code-coverage.md

### DIFF
--- a/docs/6-software-development-practices/6.5.4-code-coverage.md
+++ b/docs/6-software-development-practices/6.5.4-code-coverage.md
@@ -47,17 +47,15 @@ The provided Javascript package.json file will have everything you need in order
 
 [package](https://raw.githubusercontent.com/liatrio/devops-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/package.json ':include :type=code json')
 
-Inside your package.json file under the “scripts” section, add a section called “coverage” and use the following command
-
-`jest --coverage`
-
-Make sure that your “test” section is running the following command
-
-`jest`
-
+Inside your `package.json` file under the `"scripts"` section, add a section called `"coverage"` with the command string `"jest --coverage"`
+Make sure that your `"test"` section is running the following command
+```bash
+jest
+```
 Run your code with the following command:
-
-`npm run coverage`
+```bash
+npm run coverage
+```
 
 ## Exercise 2:
 

--- a/docs/6-software-development-practices/6.5.4-code-coverage.md
+++ b/docs/6-software-development-practices/6.5.4-code-coverage.md
@@ -47,11 +47,10 @@ The provided Javascript package.json file will have everything you need in order
 
 [package](https://raw.githubusercontent.com/liatrio/devops-bootcamp/a6ac8f1c179725b8a889b9cdb47e3cc6baba05e1/examples/codeQuality/jest-simple/package.json ':include :type=code json')
 
-Inside your `package.json` file under the `"scripts"` section, add a section called `"coverage"` with the command string `"jest --coverage"`
-Make sure that your `"test"` section is running the following command
-```bash
-jest
-```
+Inside your `package.json` file under the `"scripts"` section,  
+add a section called `"coverage"` with the command string `"jest --coverage"`,  
+and make sure that your `"test"` section is running the `"jest"` command.
+
 Run your code with the following command:
 ```bash
 npm run coverage


### PR DESCRIPTION
Change wording from "use the following command" to "with the command string" to clarify we're adding a KV to the JSON file, not running a command on the CLI