### PR TITLE
fix: negative login test in mock.test.js

### DIFF
--- a/examples/codeQuality/jest-mock/mock.test.js
+++ b/examples/codeQuality/jest-mock/mock.test.js
@@ -34,8 +34,8 @@ describe("User Info Checks (with mocked getUserInfo)", () => {
 
   test("checkUserLogin does not match expected", async () => {
     getUserInfo.mockResolvedValue({ login: "otheruser" });
-    await checkUserLogin("otheruser", "chrisjblackburn");
-    expect(getUserInfo).toHaveBeenCalledWith("otheruser");
+    await checkUserLogin("chrisjblackburn", "chrisjblackburn");
+    expect(getUserInfo).toHaveBeenCalledWith("chrisjblackburn");
     expect(logSpy).toHaveBeenCalledWith(
       "User login does NOT match expected. Got: otheruser, Expected: chrisjblackburn",
     );


### PR DESCRIPTION
Previously, the negative login test example,
where the resolved login is mocked to be "otheruser", input "otheruser" as the input, instead of "chrisjblackburn", while stating that it expects the log to report:
```
User login does NOT match expected. Got otheruser, Expected chrisjblackburn
```
That doesn't make sense if you specifically asked for "otheruser", so the test wasn't valid.